### PR TITLE
Fix bug in GenerateApiKey when using credentials

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -408,7 +408,7 @@ class System:
         username = login["credentials"]["Username"]
         password = login["credentials"]["Password"]
 
-      requestJSON = {'userName':username, 'password': password}
+    requestJSON = {'userName':username, 'password': password}
 
     # Request
     return self.connector.makeRequest(


### PR DESCRIPTION
Whitespace caused scope issue so that if you are generating an API key with credentials, you would get an error because requestJSON was not assigned